### PR TITLE
upgrade cython and downgrade numpy

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -64,6 +64,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest]
+        numpy-version: ['1.26.4', 'latest']
     steps:
       - uses: actions/checkout@v3
 
@@ -77,15 +78,16 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         with:
           path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}-numpy-${{ matrix.numpy-version }}
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
+
       - name: Window pip cache
         uses: actions/cache@v3
         if: ${{ runner.os == 'Windows' }}
         with:
           path: ~\AppData\Local\pip\Cache
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}-numpy-${{ matrix.numpy-version }}
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
 
@@ -113,6 +115,14 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         run: pip install (get-item .\dist\*.whl)
 
+      - name: Install Numpy old version
+        if: ${{ matrix.numpy-version != 'latest' }}
+        run: pip install numpy==${{ matrix.numpy-version }}
+
+      - name: Install Numpy latest version
+        if: ${{ matrix.numpy-version == 'latest' }}
+        run: pip install numpy --upgrade --force-reinstall
+
       - name: Unit testing
         run: |
           pip install -r requirements/requirements_test.txt
@@ -131,7 +141,7 @@ jobs:
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4
-        if: ${{ runner.os == 'Linux' && env.MAIN_PYTHON_VERSION == matrix.python-version }}
+        if: ${{ runner.os == 'Linux' && env.MAIN_PYTHON_VERSION == matrix.python-version && matrix.numpy-version == 'latest' }}
         with:
           path: dist/*.tar.gz
           retention-days: 7

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -38,7 +38,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         cibw_archs: ["auto"]
         cfg:
-          - {python-version: '3.9', cibw-build: 'cp39-*'}
           - {python-version: '3.10', cibw-build: 'cp310-*'}
           - {python-version: '3.11', cibw-build: 'cp311-*'}
           - {python-version: '3.12', cibw-build: 'cp312-*'}
@@ -63,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,6 +78,6 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-lincheck_ignore = [
+linkcheck_ignore = [
     "https://opensource.org/licenses/MIT",
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -77,3 +77,7 @@ source_suffix = ".rst"
 
 # The master toctree document.
 master_doc = "index"
+
+lincheck_ignore = [
+    "https://opensource.org/licenses/MIT",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "cython>=0.29",
-    "numpy==2.0.0", #oldest-supported-numpy is 1.x and hollerith supports only 2.0+
+    "cython==3.0.11",
+    "numpy==2.1.3",
     "setuptools>=70.3.0",
     "wheel>=0.43.0",
     "cibuildwheel==2.19.2",

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Operating System :: MacOS",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
         ),
     ],
     python_requires=">=3.9",
-    install_requires=["numpy>=2.0.0", "pandas>=2.0.3"],
+    install_requires=["numpy>=1.26.4", "pandas>=2.0.3"],
 )


### PR DESCRIPTION
Fixes #34 

I still need to add ci/cd for tests with both numpy versions.