### PR TITLE
bump dev version to 0.7.dev0

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -3,11 +3,11 @@
 On the ``main`` branch, use 'dev0' to denote a development version.
 For example:
 
-version_info = 0, 6, 'dev0'
+version_info = 0, 7, 'dev0'
 
 """
 # major, minor, patch
-version_info = 0, 6, "dev0"
+version_info = 0, 7, "dev0"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
0.6.0 release is happening now to pypi with python 3.13 support.